### PR TITLE
Handle query intent filter

### DIFF
--- a/rhasspyrasa_nlu_hermes/__init__.py
+++ b/rhasspyrasa_nlu_hermes/__init__.py
@@ -138,7 +138,7 @@ class NluHermesMqtt(HermesClient):
                 intent = intent_json.get("intent", {})
                 intent_name = intent.get("name", "")
 
-                if intent_name:
+                if intent_name and (query.intent_filter is None or intent_name in query.intent_filter):
                     confidence_score = float(intent.get("confidence", 0.0))
                     slots = [
                         Slot(


### PR DESCRIPTION
This patch will make the Rasa NLU module to take intent filters into account when recognizing intents. Since the Rasa API doesn't have this capability, the check is done by filtering the responses.

I don't know if it's the right place to do it, feel free to drop this. Anyway I've tested it and it works :-)